### PR TITLE
Add toleration for new control-plane taint

### DIFF
--- a/helm/dns-tester-app/templates/daemonset.yaml
+++ b/helm/dns-tester-app/templates/daemonset.yaml
@@ -19,6 +19,8 @@ spec:
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        effect: NoSchedule
       containers:
         - name: dns-tester
           image: "{{ .Values.Installation.V1.Registry.Domain }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
This PR adds a toleration for the node-role.kubernetes.io/control-plane taint to resources that already have a toleration to the deprecated node-role.kubernetes.io/master taint.
Towards giantswarm/roadmap#2471
